### PR TITLE
feat(crow-protection): implement crop defense and crow interception logic (closes #1, #2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+﻿# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This project adheres to [Semantic Versioning](https://semver.org/).
+
+---
+
+## [0.1.0] - 2025-05-15
+
+### Added
+- Harmony patch for `HoeDirt.destroyCrop` to block crow crop destruction when protection is active
+- Random daily protection chance based on pet friendship (linear scaling)
+- Logging of crop protection decisions and friendship levels
+- `CrowService` to manage protection logic and track saved crops
+- `PetService` to access pet friendship and player’s pet data
+- `SafeHelper` utility to wrap potentially risky logic and ensure game stability
+- `LogHelper` to provide consistent, context-rich mod logging

--- a/UsefulPets/Events/CrowEventHandler.cs
+++ b/UsefulPets/Events/CrowEventHandler.cs
@@ -1,0 +1,46 @@
+﻿using StardewModdingAPI;
+using StardewModdingAPI.Events;
+using UsefulPets.Services;
+using UsefulPets.Util;
+
+namespace UsefulPets.Events
+{
+    /// <summary>
+    /// Handles game events related to crow protection and delegates logic to <see cref="CrowService"/>.
+    /// </summary>
+    internal class CrowEventHandler
+    {
+        private readonly IMonitor _monitor;
+
+        /// <summary>
+        /// Gets the crow service responsible for evaluating and tracking daily crop protection.
+        /// </summary>
+        public CrowService CrowService { get; }
+
+        /// <summary>
+        /// Constructs the event handler and registers SMAPI event callbacks.
+        /// </summary>
+        /// <param name="helper">SMAPI helper instance used to hook game events.</param>
+        /// <param name="monitor">Monitor used for logging within the handler and downstream service.</param>
+        /// <param name="petService">Service used to retrieve the player's pet and friendship data.</param>
+        public CrowEventHandler(IModHelper helper, IMonitor monitor, PetService petService)
+        {
+            _monitor = monitor;
+            CrowService = new CrowService(petService, _monitor);
+
+            helper.Events.GameLoop.DayStarted += OnDayStarted;
+        }
+
+        /// <summary>
+        /// Callback for the start of a new in-game day. Evaluates crow protection for that day.
+        /// </summary>
+        private void OnDayStarted(object? sender, DayStartedEventArgs e)
+        {
+            SafeHelper.Run(_monitor, () =>
+            {
+                CrowService.EvaluateCrowProtection();
+                CrowService.ReportSavedCrops();
+            }, "CrowEventHandler.DayStarted");
+        }
+    }
+}

--- a/UsefulPets/ModEntry.cs
+++ b/UsefulPets/ModEntry.cs
@@ -1,78 +1,63 @@
-﻿using StardewModdingAPI;
-using StardewModdingAPI.Events;
-using StardewValley;
-using StardewValley.Characters;
+﻿using System.Reflection;
+using HarmonyLib;
+using StardewModdingAPI;
+using UsefulPets.Events;
+using UsefulPets.Patches;
 using UsefulPets.Services;
+using UsefulPets.Util;
 
 namespace UsefulPets
 {
     /// <summary>The main entry point for the Useful Pets mod.</summary>
     internal sealed class ModEntry : Mod
     {
-        private PetService _petService = null!;
-        private int _crowsChasedToday;
-        private readonly Random _rng = new();
+        /// <summary>Singleton instance for global access to mod services and data.</summary>
+        public static ModEntry Instance { get; private set; } = null!;
 
-        /// <summary>Initializes the mod and hooks into game events.</summary>
-        /// <param name="helper">SMAPI helper for event registration and mod access.</param>
+        /// <summary>Primary service that manages crow protection logic.</summary>
+        public CrowService CrowService { get; private set; } = null!;
+
+        /// <summary>Provides access to the player's pet and its friendship level.</summary>
+        private PetService PetService { get; set; } = null!;
+
+        private const string Context = "ModEntry";
+
+        /// <summary>
+        /// Called by SMAPI when the mod is first loaded. Initializes services and applies Harmony patches.
+        /// </summary>
+        /// <param name="helper">The SMAPI helper provided to all mods.</param>
         public override void Entry(IModHelper helper)
         {
-            _petService = new PetService();
+            Instance = this;
 
-            helper.Events.GameLoop.DayStarted += OnDayStarted;
-            helper.Events.Input.ButtonPressed += OnButtonPressed;
-        }
+            PetService = new PetService();
+            CrowService = new CrowEventHandler(helper, Monitor, PetService).CrowService;
 
-        /// <summary>Triggered at the start of each in-game day to calculate pet activity.</summary>
-        private void OnDayStarted(object? sender, DayStartedEventArgs e)
-        {
-            if (!_petService.HasPet())
+            try
             {
-                Monitor.Log("No pet found for the current player.", LogLevel.Warn);
-                return;
-            }
+                var harmony = new Harmony(ModManifest.UniqueID);
 
-            var pet = _petService.GetPlayerPet();
-            if (pet == null)
+                var target = typeof(StardewValley.TerrainFeatures.HoeDirt).GetMethod(
+                    nameof(StardewValley.TerrainFeatures.HoeDirt.destroyCrop),
+                    BindingFlags.Instance | BindingFlags.Public
+                );
+
+                var prefix = new HarmonyMethod(typeof(DestroyCropPatch), nameof(DestroyCropPatch.Prefix));
+
+                if (target != null)
+                {
+                    harmony.Patch(target, prefix: prefix);
+                    LogHelper.Debug(Monitor, Context, "Patched HoeDirt.destroyCrop (prefix)");
+                }
+                else
+                {
+                    LogHelper.Warn(Monitor, Context, "Could not find HoeDirt.destroyCrop method.");
+                }
+            }
+            catch (Exception ex)
             {
-                Monitor.Log("Pet instance is unexpectedly null.", LogLevel.Warn);
-                return;
+                LogHelper.Warn(Monitor, Context, $"Error applying Harmony patches: {ex}");
             }
-
-            var friendship = _petService.GetFriendship(pet);
-            Monitor.Log("Pet friendship: " + friendship, LogLevel.Info);
-
-            var attempts = Math.Min(friendship / 200, 5);
-            _crowsChasedToday = 0;
-
-            for (var i = 0; i < attempts; i++)
-            {
-                if (_rng.NextDouble() < 0.3)
-                    _crowsChasedToday++;
-            }
-
-            Monitor.Log("Your pet chased away " + _crowsChasedToday + " crow(s) today!", LogLevel.Info);
-        }
-
-        /// <summary>Triggered when the player interacts with the world using an action button.</summary>
-        private void OnButtonPressed(object? sender, ButtonPressedEventArgs e)
-        {
-            if (!Context.IsWorldReady || !e.Button.IsActionButton())
-                return;
-
-            var clickedTile = e.Cursor.GrabTile;
-            var character = Game1.currentLocation.characters
-                .FirstOrDefault(c => c.Tile == clickedTile);
-
-            if (character is not Pet pet)
-                return;
-
-            var petName = _petService.GetPetName(pet);
-            var message = _crowsChasedToday > 0
-                ? $"{petName} chased away {_crowsChasedToday} crow(s) today!"
-                : $"{petName} didn't see any crows today, but they stayed alert.";
-
-            Game1.drawObjectDialogue(message);
         }
     }
 }

--- a/UsefulPets/Patches/DestroyCropPatch.cs
+++ b/UsefulPets/Patches/DestroyCropPatch.cs
@@ -1,0 +1,36 @@
+﻿using HarmonyLib;
+using StardewModdingAPI;
+using StardewValley.TerrainFeatures;
+using UsefulPets.Util;
+
+namespace UsefulPets.Patches
+{
+    /// <summary>
+    /// Patch that intercepts <see cref="HoeDirt.destroyCrop"/> to optionally block crow-driven crop destruction
+    /// based on protection logic evaluated earlier in the day by <see cref="Services.CrowService"/>.
+    /// </summary>
+    [HarmonyPatch(typeof(HoeDirt), nameof(HoeDirt.destroyCrop))]
+    internal static class DestroyCropPatch
+    {
+        /// <summary>
+        /// Prefix patch for <c>HoeDirt.destroyCrop(bool)</c>. If crow protection is active, prevents the crop from being destroyed.
+        /// Otherwise, lets the base method execute normally.
+        /// </summary>
+        /// <param name="__instance">The <see cref="HoeDirt"/> instance representing the soil where the crop lives.</param>
+        /// <param name="showAnimation">Whether to show the destruction animation (passed from base game).</param>
+        /// <returns><c>false</c> to cancel the original crop destruction; <c>true</c> to allow it.</returns>
+        public static bool Prefix(HoeDirt __instance, bool showAnimation) =>
+            SafeHelper.RunTrue(ModEntry.Instance.Monitor, () =>
+            {
+                var crowService = ModEntry.Instance.CrowService;
+
+                if (!crowService.ProtectToday)
+                    return true;
+
+                crowService.CropsSavedToday++;
+                LogHelper.Debug(ModEntry.Instance.Monitor, "DestroyCropPatch", "Blocked crow from destroying a crop.");
+
+                return false;
+            }, "DestroyCropPatch.Prefix");
+    }
+}

--- a/UsefulPets/Services/CrowService.cs
+++ b/UsefulPets/Services/CrowService.cs
@@ -1,0 +1,82 @@
+﻿using StardewModdingAPI;
+using UsefulPets.Util;
+
+namespace UsefulPets.Services
+{
+    /// <summary>
+    /// Handles crow protection logic based on pet friendship level.
+    /// Evaluates whether the pet protects crops on a given day and tracks successful protections.
+    /// </summary>
+    internal class CrowService
+    {
+        private readonly PetService _petService;
+        private readonly IMonitor _monitor;
+        private readonly Random _rng = new();
+
+        /// <summary>Tracks how many crops were protected from crows on the current day.</summary>
+        public int CropsSavedToday { get; set; }
+
+        /// <summary>Indicates whether crow protection is enabled for the current day.</summary>
+        public bool ProtectToday { get; private set; }
+
+        private const string Context = "CrowService";
+
+        /// <summary>
+        /// Constructs the crow service using a reference to the pet service and SMAPI monitor.
+        /// </summary>
+        /// <param name="petService">The pet service used to retrieve pet and friendship data.</param>
+        /// <param name="monitor">The SMAPI monitor for logging.</param>
+        public CrowService(PetService petService, IMonitor monitor)
+        {
+            _petService = petService;
+            _monitor = monitor;
+        }
+
+        /// <summary>
+        /// Evaluates whether the pet will protect crops today based on friendship.
+        /// Calculates the chance to protect, rolls against it, and sets the outcome.
+        /// </summary>
+        public void EvaluateCrowProtection()
+        {
+            try
+            {
+                ProtectToday = false;
+                CropsSavedToday = 0;
+
+                var pet = _petService.GetPlayerPet();
+                if (pet == null)
+                {
+                    LogHelper.Warn(_monitor, Context, "No pet found for the current player.");
+                    return;
+                }
+
+                var friendship = _petService.GetFriendship(pet);
+                LogHelper.Debug(_monitor, Context, $"Pet friendship: {friendship}");
+
+                var chance = Math.Min(friendship / 10, 100);
+                var roll = _rng.Next(100);
+
+                ProtectToday = roll < chance;
+
+                if (ProtectToday)
+                    LogHelper.Debug(_monitor, Context, $"Crow protection activated! Chance: {chance}%, Roll: {roll}");
+                else
+                    LogHelper.Debug(_monitor, Context, $"Crow protection skipped. Chance: {chance}%, Roll: {roll}");
+            }
+            catch (Exception ex)
+            {
+                LogHelper.Warn(_monitor, Context, $"Unexpected error: {ex}");
+            }
+        }
+
+        /// <summary>
+        /// Reports how many crops were protected if protection was active and any protection occurred.
+        /// Logs the result to the debug output.
+        /// </summary>
+        public void ReportSavedCrops()
+        {
+            if (ProtectToday && CropsSavedToday > 0)
+                LogHelper.Debug(_monitor, Context, $"Your pet protected {CropsSavedToday} crop(s) from crows today!");
+        }
+    }
+}

--- a/UsefulPets/Services/PetService.cs
+++ b/UsefulPets/Services/PetService.cs
@@ -1,6 +1,6 @@
-﻿using StardewValley;
+﻿using Microsoft.Xna.Framework;
+using StardewValley;
 using StardewValley.Characters;
-using System;
 
 namespace UsefulPets.Services
 {

--- a/UsefulPets/UsefulPets.csproj
+++ b/UsefulPets/UsefulPets.csproj
@@ -3,10 +3,12 @@
         <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>0.0.2</Version>
+        <Version>0.1.0</Version>
+        <EnableHarmony>true</EnableHarmony>
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="JetBrains.Annotations" Version="2025.1.0-eap1" />
       <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.4.0" />
     </ItemGroup>
 </Project>

--- a/UsefulPets/Util/LogHelper.cs
+++ b/UsefulPets/Util/LogHelper.cs
@@ -1,0 +1,21 @@
+﻿using StardewModdingAPI;
+
+namespace UsefulPets.Util
+{
+    internal static class LogHelper
+    {
+        private const string Tag = "[UsefulPets]";
+
+        public static void Debug(IMonitor monitor, string context, string message) =>
+            monitor.Log($"{Tag} [{context}] {message}", LogLevel.Debug);
+
+        public static void Info(IMonitor monitor, string context, string message) =>
+            monitor.Log($"{Tag} [{context}] {message}", LogLevel.Info);
+
+        public static void Warn(IMonitor monitor, string context, string message) =>
+            monitor.Log($"{Tag} [{context}] {message}", LogLevel.Warn);
+
+        public static void Error(IMonitor monitor, string context, string message) =>
+            monitor.Log($"{Tag} [{context}] {message}", LogLevel.Error);
+    }
+}

--- a/UsefulPets/Util/SafeHelper.cs
+++ b/UsefulPets/Util/SafeHelper.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using StardewModdingAPI;
+
+namespace UsefulPets.Util
+{
+    /// <summary>
+    /// Utility for safely executing mod logic with fallback behavior and logging support.
+    /// Used to prevent mod errors from affecting the game's core logic.
+    /// </summary>
+    internal static class SafeHelper
+    {
+        /// <summary>
+        /// Executes an action safely. If an exception occurs, it is caught and logged, and the game continues normally.
+        /// </summary>
+        /// <param name="monitor">The SMAPI monitor used to log errors.</param>
+        /// <param name="action">The action to execute.</param>
+        /// <param name="context">A description of the context or caller for logging purposes.</param>
+        public static void Run(IMonitor monitor, Action action, string context)
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception ex)
+            {
+                LogHelper.Warn(monitor, "SafeHelper", $"Error during {context}: {ex}");
+            }
+        }
+
+        /// <summary>
+        /// Executes a function safely and returns a fallback value if an exception occurs.
+        /// </summary>
+        /// <typeparam name="T">The return type of the function.</typeparam>
+        /// <param name="monitor">The SMAPI monitor used to log errors.</param>
+        /// <param name="func">The function to evaluate.</param>
+        /// <param name="context">A description of the context or caller for logging purposes.</param>
+        /// <param name="fallback">The fallback value to return if the function fails.</param>
+        /// <returns>The result of <paramref name="func"/> or the fallback value on error.</returns>
+        public static T Run<T>(IMonitor monitor, Func<T> func, string context, T fallback)
+        {
+            try
+            {
+                return func();
+            }
+            catch (Exception ex)
+            {
+                LogHelper.Warn(monitor, "SafeHelper", $"Error during {context}: {ex}");
+                return fallback;
+            }
+        }
+
+        /// <summary>
+        /// Executes a function safely and returns true on failure.
+        /// Commonly used in Harmony prefix patches to allow game behavior to continue.
+        /// </summary>
+        public static bool RunTrue(IMonitor monitor, Func<bool> func, string context) =>
+            Run(monitor, func, context, true);
+
+        /// <summary>
+        /// Executes a function safely and returns false on failure.
+        /// </summary>
+        public static bool RunFalse(IMonitor monitor, Func<bool> func, string context) =>
+            Run(monitor, func, context, false);
+    }
+}


### PR DESCRIPTION
## Useful Pets v0.1.0

This is the first internal release of Useful Pets, a mod that gives your pet an actual role in defending your farm!

### Features

- Pet-based **crow protection system**:
  - Each morning, your pet has a chance to protect your crops based on their friendship level.
  - If successful, crow destruction is blocked entirely.
- **Harmony patch** for `HoeDirt.destroyCrop` to intercept and cancel crow-related crop damage.
- **Dynamic chance system** (friendship scales linearly, up to 100% at 1000).
- **Daily logging** of friendship, chance roll, and protection outcome.

### Infrastructure

- `CrowService`: handles protection logic, chance rolls, and tracking saved crops
- `PetService`: retrieves the player’s pet and current friendship level
- `SafeHelper`: prevents mod logic from ever interrupting gameplay, even if something fails
- `LogHelper`: standardized, context-aware logging for all systems

### Recent Changes

- Removed virtual scarecrow simulation
- Replaced with direct crow interception via `destroyCrop()` patch

---

Not yet player-facing — this version is a functional backend test to validate crop protection logic. UI elements and player feedback (letters, dialogues, config) are coming soon.
